### PR TITLE
Add Ability to Make Directories relative to .Index-File

### DIFF
--- a/Classes/CategorizedImage.cs
+++ b/Classes/CategorizedImage.cs
@@ -8,9 +8,17 @@ namespace Classes
 {
     public class CategorizedImage
     {
-        //Implizit als private deklariert
-        string LabeledAs;
-        string Path;
-        string FileName; 
+        public string LabeledAs { get; private set; }
+        public string Path { get; private set; }
+        public string FileName {get; private set; }
+
+        public CategorizedImage(string LabeledAs, string Path, string FileName)
+        {
+            this.LabeledAs = LabeledAs;
+            this.Path = Path;
+            this.FileName = FileName;
+
+            HTMLTools.ProcessedImages.Add(this); 
+        }
     }
 }

--- a/Classes/HTMLTools.cs
+++ b/Classes/HTMLTools.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using Classes.Properties; 
+using System.Text; 
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,7 +18,24 @@ namespace Classes
         }
         public static void MakeResultsFile(string Path)
         {
-             //Schreibt HTML-Files für jedes Bild in ProcessedImages
+             foreach(var Image in ProcessedImages)
+            {
+                HTMLPrinter(Image, Path); 
+            }
         }
+
+        private static void HTMLPrinter(CategorizedImage Image, string ResultsPath)
+        {
+            /// <summary> Gibt für ein Bild dessen Kategorie und weiteres als HTML-Datei aus
+            /// </summary>
+            /// 
+
+            string Added = @"TestOrdner";
+            DirectoryInfo NewDir=Directory.CreateDirectory(Path.Combine(Resources.IndexFileName, Added));
+            //Platzhalter zum  Erstellen von einem txt-File: 
+            using (FileStream fs = File.Create(ResultsPath)); 
+            
+        }
+
     }
 }

--- a/Classes/Tools.cs
+++ b/Classes/Tools.cs
@@ -61,7 +61,16 @@ namespace Tools
                     CurrentDir = Directory.GetParent(CurrentDir).ToString();
                 }
             }
-            return SearchPath; 
+            return Path.GetDirectoryName(SearchPath); 
         }
+
+        public  static DirectoryInfo  MakeDirectory(string DirName) { 
+            ///Erstellt Directory relativ zu Verzeichnis der .Index-Datei
+            ///
+
+            string FinalPath=Path.Combine(FindOrigin(), DirName);
+            DirectoryInfo NewDir=Directory.CreateDirectory(FinalPath); 
+            return NewDir; 
+            }
     }
 }

--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -48,9 +48,10 @@ namespace ConsoleApp
 
         static void Main(string[] args)
         {
-            Console.WriteLine("Before Exceptiom"); 
+            Console.WriteLine("Before Exceptiom");
+            string OriginPath = null ;
             try { 
-            string OriginPath = PathFinder.FindOrigin(); // sucht nach .Index-Datei, speichert deren Pfad
+            OriginPath = PathFinder.FindOrigin(); // sucht nach .Index-Datei, speichert deren Pfad
                 }
             catch(Exception) {Console.WriteLine(@"Couldn't find .Index-File"); }
             Console.WriteLine("Willkommen in der Konsolen-App zur Bildklassifizierung auf Grundlage von Machine Learning");

--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -1,12 +1,18 @@
 ﻿using System;
 using Tools;
+using System.IO; 
+
 namespace ConsoleApp
 {
     class Program
     {
         static void Main(string[] args)
         {
+            Console.WriteLine("Before Exceptiom"); 
+            try { 
             string OriginPath = PathFinder.FindOrigin(); // sucht nach .Index-Datei, speichert deren Pfad
+                }
+            catch(Exception) {Console.WriteLine(@"Couldn't find .Index-File"); }
             Console.WriteLine("Willkommen in der Konsolen-App zur Bildklassifizierung auf Grundlage von Machine Learning");
 
             bool IsValidKey = false;
@@ -20,6 +26,8 @@ namespace ConsoleApp
             if (PressedKey == '1') { } //Überleitung zur Bildklassifizierung
             else if (PressedKey == '2') { } //Überleitung zum Training
 
+            DirectoryInfo TrainingDir=PathFinder.MakeDirectory("TrainingModel");
+            Console.WriteLine(TrainingDir.FullName); 
         }
     }
 }

--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Tools;
-
+using System.IO;
 using MLData;
 using System.Collections.Generic;
 
@@ -10,7 +10,7 @@ namespace ConsoleApp
     {
         public static void Training(string path)
         {
-            DataCollection Data = new DataCollection(path);
+            DataCollection Data = new DataCollection(path,500);
             bool run = true;
             
             while (run)


### PR DESCRIPTION
Pull Request für wichtiges Zwischenergebnis. Wir können jetzt mit der FindOrigin()-Methode und der MakeDirectory()-Methode den Pfad zur .Index-Datei ausgeben lassen bzw. einen Ordner relativ zum Pfad zur .Index-Datei erstellen. 